### PR TITLE
Approxfun support

### DIFF
--- a/src/Domains.jl
+++ b/src/Domains.jl
@@ -19,7 +19,7 @@ import Base: ∘
 import Base: cross, ×
 
 # Set operations
-import Base: intersect, union, setdiff, in
+import Base: intersect, union, setdiff, in, isempty
 
 # Arrays
 import Base: size, length, ndims, getindex, eltype, ndims

--- a/src/Domains.jl
+++ b/src/Domains.jl
@@ -132,7 +132,7 @@ export real_line, halfline, negative_halfline
 export interval, leftendpoint, rightendpoint
 export similar_interval
 # from domains/simple.jl
-export UnitBall, Disk, Ball, Cube, Simplex, UnitSimplex, UnitSphere
+export UnitBall, Disk, Ball, Cube, Simplex, UnitSimplex, UnitSphere, Point
 export disk, ball, cube, simplex, cylinder, rectangle
 # from domains/circle.jl
 export Circle, Sphere

--- a/src/Domains.jl
+++ b/src/Domains.jl
@@ -22,7 +22,7 @@ import Base: cross, ×
 import Base: intersect, union, setdiff, in, isempty
 
 # Arrays
-import Base: size, length, ndims, getindex, eltype, ndims
+import Base: size, length, ndims, getindex, eltype, ndims, hash
 import Base: inv
 import Base: isreal
 import Base: zero

--- a/src/Domains.jl
+++ b/src/Domains.jl
@@ -19,7 +19,7 @@ import Base: ∘
 import Base: cross, ×
 
 # Set operations
-import Base: intersect, union, setdiff, in, isempty
+import Base: intersect, union, setdiff, in, isempty, minimum, maximum
 
 # Arrays
 import Base: size, length, ndims, getindex, eltype, ndims, hash
@@ -119,6 +119,8 @@ export mapping, map_domain
 
 # from generic/arithmetics.jl
 export rotate
+
+export infimum, supremum
 
 
 ## Specific domains

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -301,3 +301,21 @@ function intersect(d1::Interval{L1,R1,T}, d2::Interval{L2,R2,T}) where {L1,R1,L2
         interval(max(a1, a2), min(b1, b2))
     end
 end
+
+function setdiff(d1::AbstractInterval{T}, d2::AbstractInterval{T}) where T
+    a1 = leftendpoint(d1)
+    b1 = rightendpoint(d1)
+    a2 = leftendpoint(d2)
+    b2 = rightendpoint(d2)
+
+    a1 > b1 && return d1
+    a2 > b2 && return d1
+    b1 < a2 && return d1
+    a1 < a2 < b1 ≤ b2 && return interval(a1, a2)
+    a1 < a2 ≤ b2 < b1 && return interval(a1, a2) ∪ interval(b2, b1)
+    a2 ≤ a1 < b2 < b1 && return interval(b2, b1)
+    a2 ≤ a1 ≤ b1 ≤ b2 && return EmptySpace{T}()
+
+    @assert b2 ≤ a1
+    d1
+end

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -18,6 +18,21 @@ rightendpoint(d::AbstractInterval) = d.b
 isempty(d::AbstractInterval) = leftendpoint(d) > rightendpoint(d)
 
 
+
+function infimum(d::AbstractInterval{T}) where T
+    a = leftendpoint(d)
+    b = rightendpoint(d)
+    a > b && throw(ArgumentError("Infimum not defined for empty intervals"))
+    a
+end
+
+function supremum(d::AbstractInterval{T}) where T
+    a = leftendpoint(d)
+    b = rightendpoint(d)
+    a > b && throw(ArgumentError("Supremum not defined for empty intervals"))
+    b
+end
+
 ## Some special intervals
 # - the unit interval [0,1]
 # - the 'Chebyshev' interval [-1,1]
@@ -57,6 +72,9 @@ unitinterval(::Type{T} = Float64) where {T} = UnitInterval{T}()
 leftendpoint(d::UnitInterval{T}) where {T} = zero(T)
 rightendpoint(d::UnitInterval{T}) where {T} = one(T)
 
+minimum(d::UnitInterval) = infimum(d)
+maximum(d::UnitInterval) = supremum(d)
+
 
 "The closed interval [-1,1]."
 struct ChebyshevInterval{T} <: FixedInterval{T}
@@ -64,6 +82,9 @@ end
 
 leftendpoint(d::ChebyshevInterval{T}) where {T} = -one(T)
 rightendpoint(d::ChebyshevInterval{T}) where {T} = one(T)
+
+minimum(d::ChebyshevInterval) = infimum(d)
+maximum(d::ChebyshevInterval) = supremum(d)
 
 
 real_line(::Type{T} = Float64) where {T <: AbstractFloat} = FullSpace{T}()
@@ -77,6 +98,10 @@ halfline(::Type{T} = Float64) where {T <: AbstractFloat} = Halfline{T}()
 
 leftendpoint(d::Halfline{T}) where {T} = zero(T)
 rightendpoint(d::Halfline{T}) where {T} = T(Inf)
+
+
+minimum(d::Halfline) = infimum(d)
+maximum(d::Halfline) = throw(ArgumentError("$d is unbounded. Use supremum."))
 
 # A half-open domain is neither open nor closed
 isclosed(d::Halfline) = false
@@ -101,6 +126,10 @@ negative_halfline(::Type{T} = Float64) where {T <: AbstractFloat} = NegativeHalf
 
 leftendpoint(d::NegativeHalfline{T}) where {T} = -T(Inf)
 rightendpoint(d::NegativeHalfline{T}) where {T} = zero(T)
+
+
+minimum(d::NegativeHalfline) = throw(ArgumentError("$d is unbounded. Use infimum."))
+maximum(d::NegativeHalfline) = supremum(d)
 
 isclosed(d::NegativeHalfline) = false
 isopen(d::NegativeHalfline) = true
@@ -177,6 +206,12 @@ Interval{L,R}(::Type{T}, a, b) where {L,R,T} = Interval{L,R}(convert(T, a), conv
 
 leftendpoint(d::Interval) = d.a
 rightendpoint(d::Interval) = d.b
+
+minimum(d::Interval{:closed}) = infimum(d)
+minimum(d::Interval{:open}) = throw(ArgumentError("$d is open on the left. Use infimum."))
+maximum(d::Interval{L,:closed}) where L = supremum(d)
+maximum(d::Interval{L,:open}) where L = throw(ArgumentError("$d is open on the right. Use supremum."))
+
 
 # The interval is closed if it is closed at both endpoints, and open if it
 # is open at both endpoints. In all other cases, it is neither open nor closed.

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -273,6 +273,11 @@ end
 
 
 show(io::IO, d::AbstractInterval) = print(io, "the interval [", leftendpoint(d), ", ", rightendpoint(d), "]")
+show(io::IO, d::Interval{:closed,:closed}) = print(io, "the interval [", leftendpoint(d), ", ", rightendpoint(d), "]")
+show(io::IO, d::Interval{:closed,:open}) = print(io, "the interval [", leftendpoint(d), ", ", rightendpoint(d), ")")
+show(io::IO, d::Interval{:open,:closed}) = print(io, "the interval (", leftendpoint(d), ", ", rightendpoint(d), "]")
+show(io::IO, d::Interval{:open,:open}) = print(io, "the interval (", leftendpoint(d), ", ", rightendpoint(d), ")")
+
 
 function union(d1::Interval{L1,R1,T}, d2::Interval{L2,R2,T}) where {L1,R1,L2,R2,T}
     a1 = leftendpoint(d1)
@@ -280,13 +285,16 @@ function union(d1::Interval{L1,R1,T}, d2::Interval{L2,R2,T}) where {L1,R1,L2,R2,
     a2 = leftendpoint(d2)
     b2 = rightendpoint(d2)
 
-    if (b1 < a2) || (a1 > b2)
+    if (b1 < a2) || (b2 < a1) || (b1 == a2 && R1 == L2 == :open) ||
+                    (b2 == a1 && R2 == L1 == :open)
         UnionDomain(d1, d2)
     else
-        # TODO: add some logic to determine open and closed nature of endpoints of new interval
-        interval(min(a1, a2), max(b1, b2))
+        a = min(a1, a2)
+        b = max(b1, b2)
+        Interval{a == a1 ? L1 : L2, b == b1 ? R1 : R2}(a, b)
     end
 end
+
 
 function intersect(d1::Interval{L1,R1,T}, d2::Interval{L2,R2,T}) where {L1,R1,L2,R2,T}
     a1 = leftendpoint(d1)

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -248,8 +248,8 @@ for op in (:+, :-)
     @eval $op(d::AbstractInterval, x::Real) = similar_interval(d, $op(leftendpoint(d),x), $op(rightendpoint(d),x))
 end
 
-+(x::Number, d::AbstractInterval) = similar_interval(d, x+leftendpoint(d), x+rightendpoint(d))
--(x::Number, d::AbstractInterval) = similar_interval(d, x-rightendpoint(d), x-leftendpoint(d))
++(x::Real, d::AbstractInterval) = similar_interval(d, x+leftendpoint(d), x+rightendpoint(d))
+-(x::Real, d::AbstractInterval) = similar_interval(d, x-rightendpoint(d), x-leftendpoint(d))
 
 for op in (:*, :/)
     @eval function $op(d::AbstractInterval, x::Real)

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -200,6 +200,22 @@ similar_interval(d::Interval{L,R,T}, a, b) where {L,R,T} =
 #################################
 
 
+for STyp in (:Domain, :AbstractInterval, :FixedInterval)
+    @eval begin
+        convert(::Type{$STyp{T}}, d::Interval{L,R,T}) where {L,R,T} = d
+        convert(::Type{$STyp{T}}, d::Interval{L,R}) where {L,R,T} =
+            Interval{L,R,T}(T(leftendpoint(d)), T(rightendpoint(d)))
+    end
+
+    for Typ in (:ChebyshevInterval, :UnitInterval, :Halfline, :NegativeHalfline)
+        @eval begin
+            convert(::Type{$STyp{T}}, d::$Typ{T}) where {T} = d
+            convert(::Type{$STyp{T}}, d::$Typ) where T = $Typ{T}
+        end
+    end
+end
+
+
 convert(::Type{Interval{L,R,T}}, d::AbstractInterval{S}) where {L,R,T,S} =
     Interval{L,R,T}(leftendpoint(d), rightendpoint(d))
 

--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -15,6 +15,8 @@ leftendpoint(d::AbstractInterval) = d.a
 "The right endpoint of the interval."
 rightendpoint(d::AbstractInterval) = d.b
 
+isempty(d::AbstractInterval) = leftendpoint(d) > rightendpoint(d)
+
 
 ## Some special intervals
 # - the unit interval [0,1]
@@ -182,6 +184,8 @@ isclosed(d::ClosedInterval) = true
 isopen(d::OpenInterval) = true
 isclosed(d::Interval) = false
 isopen(d::Interval) = false
+isempty(d::Union{OpenInterval,HalfOpenLeftInterval,HalfOpenRightInterval}) = leftendpoint(d) ≥ rightendpoint(d)
+
 
 iscompact(d::Interval) = true
 

--- a/src/domains/simple.jl
+++ b/src/domains/simple.jl
@@ -114,3 +114,15 @@ for op in (:*,:+)
         $op(v::AbstractVector,a::Point) = map(y->$op(y,a),v)
     end
 end
+
+
+function setdiff(d::Interval{L,R,T}, p::Point{T}) where {L,R,T}
+    a = leftendpoint(d)
+    b = rightendpoint(d)
+
+    a == p.x && return Interval{:open,R}(a,b)
+    a < p.x < b && return Interval{L,:open}(a,p.x) ∪ Interval{:open,R}(p.x,b)
+    b == p.x && return Interval{L,:open}(a,b)
+
+    return d
+end

--- a/src/domains/simple.jl
+++ b/src/domains/simple.jl
@@ -70,3 +70,46 @@ cube(a::AbstractVector{T}, b::AbstractVector{T}) where {T} = cube(tuple(a...), t
 cylinder(::Type{T} = Float64) where {T} = disk(T) × unitinterval(T)
 
 cylinder(radius::T, length::T) where {T} = disk(radius) × interval(0,length)
+
+doc"""
+    Point(x)
+
+represents a single point at `x`.
+"""
+struct Point{T} <: Domain{T}
+    x::T
+end
+
+convert(::Type{Number}, d::Point) = d.x
+convert(::Type{<:Number}, d::Point) = N(d.x)
+
+convert(::Type{Domain}, c::Number) = Point(c)
+convert(::Type{Domain{T}}, c::Number) where T = Point(convert(T,c))
+
+
+
+==(a::Point,b::Point) = a.x == b.x
+indomain(x, d::Point) = x == d.x
+
+for op in (:*,:+,:-)
+    @eval begin
+        $op(c::Number, d::Point)  = Point($op(c,d.x))
+        $op(d::Point,  c::Number) = Point($op(d.x,c))
+    end
+end
+
+
+/(d::Point,  c::Number) = Point(d.x/c)
+\(c::Number, d::Point)  = Point(c\d.x)
+
+for op in (:+,:-)
+    @eval $op(a::Point, b::Point) = Point($op(a.x,b.x))
+end
+
+
+for op in (:*,:+)
+    @eval begin
+        $op(a::Point,v::AbstractVector) = map(y->$op(a,y),v)
+        $op(v::AbstractVector,a::Point) = map(y->$op(y,a),v)
+    end
+end

--- a/src/domains/simple.jl
+++ b/src/domains/simple.jl
@@ -86,6 +86,7 @@ convert(::Type{<:Number}, d::Point) = N(d.x)
 convert(::Type{Domain}, c::Number) = Point(c)
 convert(::Type{Domain{T}}, c::Number) where T = Point(convert(T,c))
 
+convert(::Type{Domain}, s::Set) = UnionDomain(map(Domain,collect(s)))
 
 
 ==(a::Point,b::Point) = a.x == b.x

--- a/src/domains/simple.jl
+++ b/src/domains/simple.jl
@@ -83,6 +83,10 @@ end
 convert(::Type{Number}, d::Point) = d.x
 convert(::Type{<:Number}, d::Point) = N(d.x)
 
+convert(::Type{Domain{T}}, d::Point{T}) where T = d
+convert(::Type{Domain{T}}, d::Point) where T = Point(T(d.x))
+
+
 convert(::Type{Domain}, c::Number) = Point(c)
 convert(::Type{Domain{T}}, c::Number) where T = Point(convert(T,c))
 

--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -52,7 +52,7 @@ FullSpace(::Type{T}) where {T} = FullSpace{T}()
 fullspace(d::Domain) = FullSpace{eltype(d)}()
 
 euclideanspace(n::Val{N}) where {N} = euclideanspace(n, Float64)
-euclideanspace(::Val{N}, ::Type{T}) where {N,T} = FullSpace(Point{N,T})
+euclideanspace(::Val{N}, ::Type{T}) where {N,T} = FullSpace(SVector{N,T})
 
 indomain(x::T, d::FullSpace{T}) where {T} = true
 indomain(x::S, d::FullSpace{T}) where {T,S} = promotes_to(S,T) == Val{true}

--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -16,6 +16,8 @@ emptyspace(d::Domain{T}) where {T} = EmptySpace{T}()
 
 indomain(x::T, d::EmptySpace{T}) where {T} = false
 
+isempty(d::EmptySpace) = true
+
 # Arithmetic operations
 
 union(d1::EmptySpace{T}, d2::EmptySpace{T}) where {T} = d1

--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -70,3 +70,7 @@ intersect(d1::FullSpace{T}, d2::Domain{T}) where {T} = d2
 
 
 show(io::IO, d::FullSpace) = print(io, "the full space with eltype ", eltype(d))
+
+
+convert(::Type{Domain}, ::Type{T}) where T = FullSpace{T}()
+convert(::Type{Domain{S}}, ::Type{T}) where {T,S} = convert(Domain{S}, convert(Domain, T))

--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -26,6 +26,10 @@ intersect(d1::EmptySpace{T}, d2::EmptySpace{T}) where {T} = d1
 intersect(d1::Domain{T}, d2::EmptySpace{T}) where {T} = d2
 intersect(d1::EmptySpace{T}, d2::Domain{T}) where {T} = d1
 
+setdiff(d1::EmptySpace{T}, d2::EmptySpace{T}) where {T} = d1
+setdiff(d1::EmptySpace{T}, d2::Domain{T}) where {T} = d1
+setdiff(d1::Domain{T}, d2::EmptySpace{T}) where {T} = d1
+
 # TODO: verify these - should we restrict x?
 (+)(d::EmptySpace, x::Number) = d
 (*)(d::EmptySpace, x::Number) = d

--- a/src/generic/arithmetics.jl
+++ b/src/generic/arithmetics.jl
@@ -30,10 +30,3 @@ rotate(d::Domain3d, phi, theta, psi) = rotation_map(phi,theta,psi) * d
 rotate(d::Domain2d, theta, center::SVector{T}) where {T} = Translation(center) * (rotation_map(theta) * (Translation(-center) * d))
 
 rotate(d::Domain3d, phi, theta, psi, center::SVector{T}) where {T} = Translation(center) * (rotation_map(phi,theta,psi) * (Translation(-center) * d))
-
-
-## union domain operations
-
-for op in (:+, :*)
-    @eval $op(domain::UnionDomain, x) = UnionDomain(broadcast($op, domain.domains, x))
-end

--- a/src/generic/domain.jl
+++ b/src/generic/domain.jl
@@ -51,9 +51,14 @@ const Domain4d{T} = EuclideanDomain{4,T}
 # Concrete subtypes should implement `indomain`, rather than `in`.
 in(x::T, d::Domain{T}) where {T} = indomain(x, d)
 
-in(x::S, d::Domain{T}) where {T,S} = in(convert(T, x), d)
+function in(x, d::Domain)
+   T = promote_type(typeof(x), eltype(d))
+   T == Any && return false
+   in(convert(T, x), convert(Domain{T}, d))
+end
 
 # Be forgiving for a 1D case. Good idea or not? This is really an isomorphism.
+# dlfivefifty: NOT!
 in(x::SVector{1,T}, d::Domain{T}) where {T <: Number}  = in(x[1], d)
 
 # The user may supply a vector. We attempt to convert it to the right space.

--- a/src/generic/domain.jl
+++ b/src/generic/domain.jl
@@ -62,3 +62,8 @@ in(x::SVector{1,T}, d::Domain{T}) where {T <: Number}  = in(x[1], d)
 in(x::Vector{T}, d::Domain) where {T} = in(convert(eltype(d), x), d)
 
 isreal(d::Domain) = isreal(spaceof(d))
+
+infimum(d::Domain) = minimum(d)  # if the minimum exists, then it is also the infimum
+supremum(d::Domain) = maximum(d)  # if the maximum exists, then it is also the supremum
+
+# override minimum and maximum for closed sets

--- a/src/generic/domain.jl
+++ b/src/generic/domain.jl
@@ -31,11 +31,8 @@ If the type `T` is a container type, the elements of `T` may have a different
 subeltype(d::Domain) = subeltype(spaceof(d))
 subeltype(::Type{T}) where {T} = subeltype(GSpace{T})
 
-"We use `Point{N,T}` as a synonym for `SVector{N,T}`."
-const Point{N,T} = SVector{N,T}
-
-"A `EuclideanDomain` is any domain whose eltype is `Point{N,T}`."
-const EuclideanDomain{N,T} = Domain{Point{N,T}}
+"A `EuclideanDomain` is any domain whose eltype is `SVector{N,T}`."
+const EuclideanDomain{N,T} = Domain{SVector{N,T}}
 
 
 # Convenient aliases

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -29,6 +29,10 @@ UnionDomain(domains::Tuple) = UnionDomain(domains...)
 elements(d::UnionDomain) = d.domains
 
 union(d1::Domain{T}, d2::Domain{T}) where {T} = d1 == d2 ? d1 : UnionDomain(d1, d2)
+function union(d1::Domain{S}, d2::Domain{T}) where {S,T}
+    TS = promote_type(S, T)
+    union(convert(Domain{TS}, d1), convert(Domain{TS}, d2))
+end
 
 # Avoid creating nested unions
 union(d1::UnionDomain, d2::Domain) = UnionDomain(elements(d1)..., d2)

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -85,7 +85,7 @@ setdiff(d1::UnionDomain, d2::UnionDomain) = UnionDomain(setdiff.(elements(d1), d
 function setdiff(d1::UnionDomain, d2::Domain)
     s = Set(elements(d1))
     # check if any element is in d1 and just remove
-    s2 = setdiff(s, tuple(d2))
+    s2 = Set(setdiff(s, tuple(d2)))
     s2 ≠ s && return UnionDomain(s2)
 
     UnionDomain(setdiff.(elements(d1), d2))

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -76,6 +76,11 @@ end
 \(x::Number, domain::UnionDomain) = UnionDomain(broadcast(\, x, elements(domain)))
 
 
+for (op, mop) in ((:minimum, :min), (:maximum, :max), (:infimum, :min), (:supremum, :max))
+    @eval $op(d::UnionDomain) = mapreduce($op, $mop, elements(d))
+end
+
+
 setdiff(d1::UnionDomain, d2::UnionDomain) = UnionDomain(setdiff.(elements(d1), d2))
 function setdiff(d1::UnionDomain, d2::Domain)
     s = Set(elements(d1))

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -39,7 +39,6 @@ union(d1::Domain, d2::UnionDomain) = UnionDomain(d1, elements(d2)...)
 # The union of domains corresponds to a logical OR of their characteristic functions
 indomain(x, d::UnionDomain) = mapreduce(d->in(x, d), |, elements(d))
 
-(+)(d1::Domain, d2::Domain) = union(d1, d2)
 (|)(d1::Domain, d2::Domain) = union(d1, d2)
 
 

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -24,6 +24,7 @@ function UnionDomain(domains::Domain...)
 end
 
 UnionDomain(domains::AbstractVector) = UnionDomain{typeof(domains),eltype(eltype(domains))}(domains)
+UnionDomain(domains::Tuple) = UnionDomain(domains...)
 
 elements(d::UnionDomain) = d.domains
 

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -43,6 +43,14 @@ indomain(x, d::UnionDomain) = mapreduce(d->in(x, d), |, elements(d))
 (|)(d1::Domain, d2::Domain) = union(d1, d2)
 
 
+function ==(a::UnionDomain, b::UnionDomain)
+    length(elements(a)) ≠ length(elements(b)) && return false
+    for (c, d) in zip(a.domains, b.domains)
+        c ≠ d && return false
+    end
+    return true
+end
+
 function show(io::IO, d::UnionDomain)
     print(io, "a union of $(nb_elements(d)) domains:\n")
     for i=1:nb_elements(d)

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -40,7 +40,7 @@ indomain(x, d::UnionDomain) = mapreduce(d->in(x, d), |, elements(d))
 (|)(d1::Domain, d2::Domain) = union(d1, d2)
 
 
-==(a::UnionDomain, b::UnionDomain) = elements(a) == elements(b)
+==(a::UnionDomain, b::UnionDomain) = a.domains == b.domains
 
 function show(io::IO, d::UnionDomain)
     print(io, "a union of $(nb_elements(d)) domains:\n")

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -58,6 +58,18 @@ function show(io::IO, d::UnionDomain)
 end
 
 
+## ualgebra
+
+for op in (:+, :-, :*, :/)
+    @eval begin
+        $op(domain::UnionDomain, x::Number) = UnionDomain(broadcast($op, domain.domains, x))
+        $op(x::Number, domain::UnionDomain) = UnionDomain(broadcast($op, x, domain.domains))
+    end
+end
+
+\(x::Number, domain::UnionDomain) = UnionDomain(broadcast(\, x, domain.domains))
+
+
 ###################################
 # The intersection of two domains
 ###################################

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -74,7 +74,7 @@ end
 \(x::Number, domain::UnionDomain) = UnionDomain(broadcast(\, x, domain.domains))
 
 
-setdiff(d1::UnionDomain, d2::Domain) = UnionDomain(setdiff.(d1.domains, d2))
+setdiff(d1::UnionDomain, d2) = UnionDomain(setdiff.(d1.domains, d2))
 
 ###################################
 # The intersection of two domains

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -74,6 +74,8 @@ end
 \(x::Number, domain::UnionDomain) = UnionDomain(broadcast(\, x, domain.domains))
 
 
+setdiff(d1::UnionDomain, d2::Domain) = UnionDomain(setdiff.(d1.domains, d2))
+
 ###################################
 # The intersection of two domains
 ###################################
@@ -137,7 +139,10 @@ end
 
 DifferenceDomain(d1::Domain{T}, d2::Domain{T}) where {T} = DifferenceDomain{typeof(d1),typeof(d2),T}(d1,d2)
 
-setdiff(d1::Domain, d2::Domain) = DifferenceDomain(d1, d2)
+function setdiff(d1::Domain{T}, d2::Domain{T}) where T
+    d1 == d2 && return EmptySpace{T}()
+    DifferenceDomain(d1, d2)
+end
 
 # The difference between two domains corresponds to a logical AND NOT of their characteristic functions
 indomain(x, d::DifferenceDomain) = indomain(x, d.d1) && (~indomain(x, d.d2))

--- a/src/generic/setoperations.jl
+++ b/src/generic/setoperations.jl
@@ -9,6 +9,7 @@
 """
 A `UnionDomain` represents the union of a set of domains.
 """
+# DD can be any collection type: a Tuple, or a Vector
 struct UnionDomain{DD,T} <: Domain{T}
     domains  ::  DD
 end
@@ -21,6 +22,8 @@ function UnionDomain(domains::Domain...)
     end
     UnionDomain{typeof(domains),T}(domains)
 end
+
+UnionDomain(domains::AbstractVector) = UnionDomain{typeof(domains),eltype(eltype(domains))}(domains)
 
 elements(d::UnionDomain) = d.domains
 

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -142,19 +142,93 @@ function test_interval(T = Float64)
     ## Some mappings preserve the interval structure
     # Translation
     d = interval(zero(T), one(T))
+    @test d == +d
+
     d2 = d + one(T)
     @test typeof(d2) == typeof(d)
     @test leftendpoint(d2) == one(T)
     @test rightendpoint(d2) == 2*one(T)
 
+    d2 = one(T) + d
+    @test typeof(d2) == typeof(d)
+    @test leftendpoint(d2) == one(T)
+    @test rightendpoint(d2) == 2*one(T)
+
+    d2 = d - one(T)
+    @test typeof(d2) == typeof(d)
+    @test leftendpoint(d2) == -one(T)
+    @test rightendpoint(d2) == zero(T)
+
+    d2 = -d
+    @test typeof(d2) == typeof(d)
+    @test leftendpoint(d2) == -one(T)
+    @test rightendpoint(d2) == zero(T)
+
+    d2 = one(T) - d
+    @test d2 == d
+
+    # translation for UnitInterval
     # Does a shifted unit interval return an interval?
     d = UnitInterval{T}()
     d2 = d + one(T)
     @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == one(T)
+    @test rightendpoint(d2) == 2*one(T)
+
+    d2 = one(T) + d
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == one(T)
+    @test rightendpoint(d2) == 2*one(T)
+
+    d2 = d - one(T)
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == -one(T)
+    @test rightendpoint(d2) == zero(T)
+
+    d2 = -d
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == -one(T)
+    @test rightendpoint(d2) == zero(T)
+
+    d2 = one(T) - d
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == zero(T)
+    @test rightendpoint(d2) == one(T)
+
+
+    # translation for ChebyshevInterval
+    d = ChebyshevInterval{T}()
+    d2 = d + one(T)
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == zero(T)
+    @test rightendpoint(d2) == 2*one(T)
+
+    d2 = one(T) + d
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == zero(T)
+    @test rightendpoint(d2) == 2*one(T)
+
+    d2 = d - one(T)
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == -2one(T)
+    @test rightendpoint(d2) == zero(T)
+
+    @test -d == d
+
+    d2 = one(T) - d
+    @test typeof(d2) <: AbstractInterval
+    @test leftendpoint(d2) == zero(T)
+    @test rightendpoint(d2) == 2one(T)    
+
 
     # Scaling
     d = interval(zero(T), one(T))
     d3 = T(2) * d
+    @test typeof(d3) == typeof(d)
+    @test leftendpoint(d3) == zero(T)
+    @test rightendpoint(d3) == T(2)
+
+    d3 = d * T(2)
     @test typeof(d3) == typeof(d)
     @test leftendpoint(d3) == zero(T)
     @test rightendpoint(d3) == T(2)
@@ -164,6 +238,12 @@ function test_interval(T = Float64)
     @test typeof(d4) == typeof(d)
     @test leftendpoint(d4) == zero(T)
     @test rightendpoint(d4) == T(1)/T(2)
+
+    d4 = T(2) \ d
+    @test typeof(d4) == typeof(d)
+    @test leftendpoint(d4) == zero(T)
+    @test rightendpoint(d4) == T(1)/T(2)
+
 
     # Union and intersection of intervals
     i1 = interval(zero(T), one(T))
@@ -419,6 +499,7 @@ function test_cartesianproduct_domain()
 
 end
 
+
 function test_set_operations()
 
   d1 = disk()
@@ -426,8 +507,8 @@ function test_set_operations()
   d3 = rectangle(-.5,-.1,.5,.1)
 
   println("- union")
-  u1 = d1+d2
-  u2 = u1+d3
+  u1 = d1∪d2
+  u2 = u1∪d3
 
   u3 = d3|u1
   u4 = u1|u2

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -107,6 +107,9 @@ function test_interval(T = Float64)
 
     @test leftendpoint(d) == zero(T)
     @test rightendpoint(d) == one(T)
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+
     @test isclosed(d)
     @test !isopen(d)
     @test iscompact(d)
@@ -115,6 +118,9 @@ function test_interval(T = Float64)
     d = UnitInterval{T}()
     @test leftendpoint(d) == zero(T)
     @test rightendpoint(d) == one(T)
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+
     @test isclosed(d)
     @test !isopen(d)
     @test iscompact(d)
@@ -122,6 +128,9 @@ function test_interval(T = Float64)
     d = ChebyshevInterval{T}()
     @test leftendpoint(d) == -one(T)
     @test rightendpoint(d) == one(T)
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+
     @test isclosed(d)
     @test !isopen(d)
     @test iscompact(d)
@@ -129,6 +138,10 @@ function test_interval(T = Float64)
     d = halfline(T)
     @test leftendpoint(d) == zero(T)
     @test rightendpoint(d) == T(Inf)
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test supremum(d) == rightendpoint(d)
+    @test_throws ArgumentError maximum(d)
+
     @test !isclosed(d)
     @test !isopen(d)
     @test !iscompact(d)
@@ -141,6 +154,10 @@ function test_interval(T = Float64)
     d = negative_halfline(T)
     @test leftendpoint(d) == -T(Inf)
     @test rightendpoint(d) == zero(T)
+    @test infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+    @test_throws ArgumentError minimum(d)
+
     @test !isclosed(d)
     @test isopen(d)
     @test !iscompact(d)
@@ -153,21 +170,36 @@ function test_interval(T = Float64)
     @test !isclosed(d)
     @test leftendpoint(d)∉d
     @test rightendpoint(d)∉d
+    @test infimum(d) == leftendpoint(d)
+    @test supremum(d) == rightendpoint(d)
+    @test_throws ArgumentError minimum(d)
+    @test_throws ArgumentError maximum(d)
+
     d = Domains.closed_interval()
     @test !isopen(d)
     @test isclosed(d)
     @test leftendpoint(d) ∈ d
     @test rightendpoint(d) ∈ d
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+
     d = HalfOpenLeftInterval()
     @test !isopen(d)
     @test !isclosed(d)
     @test leftendpoint(d) ∉ d
     @test rightendpoint(d) ∈ d
+    @test infimum(d) == leftendpoint(d)
+    @test maximum(d) == supremum(d) == rightendpoint(d)
+    @test_throws ArgumentError minimum(d)
+
     d = HalfOpenRightInterval()
     @test !isopen(d)
     @test !isclosed(d)
     @test leftendpoint(d) ∈ d
     @test rightendpoint(d) ∉ d
+    @test minimum(d) == infimum(d) == leftendpoint(d)
+    @test supremum(d) == rightendpoint(d)
+    @test_throws ArgumentError maximum(d)
 
     @test typeof(UnitInterval{Float64}(interval(0.,1.))) <: UnitInterval
     @test typeof(ChebyshevInterval{Float64}(interval(-1,1.))) <: ChebyshevInterval
@@ -338,6 +370,12 @@ function test_interval(T = Float64)
     @test zero(T) ∉ Interval{:open,:closed}(zero(T),zero(T))
     @test isempty(Interval{:closed,:open}(zero(T),zero(T)))
     @test zero(T) ∉ Interval{:closed,:open}(zero(T),zero(T))
+
+    d = interval(one(T),zero(T))
+    @test_throws ArgumentError minimum(d)
+    @test_throws ArgumentError maximum(d)
+    @test_throws ArgumentError infimum(d)
+    @test_throws ArgumentError supremum(d)
 end
 
 function test_unitball()
@@ -641,6 +679,8 @@ function test_set_operations()
   @test d/2 == (d1/2) ∪ (d2/2)
   @test 2\d == (2\d1) ∪ (2\d2)
 
+  @test infimum(d) == minimum(d) == 0
+  @test supremum(d) == maximum(d) == 3
 
   println("- different types")
   d̃1 = interval(0,1)

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -60,12 +60,18 @@ function test_fullspace()
     @test v[0.1,0.2] ∈ d2
 end
 
+
 function test_interval(T = Float64)
     println("- intervals")
 
     d = interval(zero(T), one(T))
     @test T(0.5) ∈ d
     @test T(1.1) ∉ d
+    @test 0.5f0 ∈ d
+    @test 1.1f0 ∉ d
+    @test BigFloat(0.5) ∈ d
+    @test BigFloat(1.1) ∉ d
+
     @test leftendpoint(d) == zero(T)
     @test rightendpoint(d) == one(T)
     @test isclosed(d)

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -68,6 +68,7 @@ function test_fullspace()
 end
 
 function test_point()
+    println("- points")
     d = Domain(1.0)
     @test d isa Point
     @test 1 ∈ d
@@ -81,6 +82,8 @@ function test_point()
     @test d*2 == Domain(2.0)
     @test d/2 == Domain(0.5)
     @test 2\d == Domain(0.5)
+
+    @test Domain(Set([1,2,3])) == Point(1) ∪ Point(2) ∪ Point(3)
 end
 
 
@@ -478,7 +481,7 @@ function test_arithmetics()
     @test v[0.1, -0.1, 0.1] ∉ DS
 
     # domain difference
-    DS = D-S
+    DS = D\S
     @test v[0.1, 0.1, 0.1] ∉ DS
 
     D1 = 2*D
@@ -559,9 +562,11 @@ function test_set_operations()
   @test ũ2 == ũ2
   @test u1 == ũ2
 
+  # ordering doesn't matter
+  @test UnionDomain(d1,d2) == UnionDomain(d2,d1)
 
   show(io,u1)
-  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"
+  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n\t2.\t: the 2-dimensional unit ball\n"
 
   println("- intersection")
   d1 = disk()

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -58,6 +58,10 @@ function test_fullspace()
 
     d2 = FullSpace(SVector{2,Float64})
     @test v[0.1,0.2] ∈ d2
+
+    @test d2 == Domain(SVector{2,Float64})
+    @test d2 == convert(Domain,SVector{2,Float64})
+    @test d2 == convert(Domain{SVector{2,Float64}}, SVector{2,Float64})
 end
 
 
@@ -573,12 +577,12 @@ function test_set_operations()
   d2 = interval(2,3)
   d = d1 ∪ d2
 
-  @test d+1 == (d1+1)∪(d2+1)
-  @test d-1 == (d1-1)∪(d2-1)
-  @test 2d == (2d1)∪(2d2)
-  @test d*2 == (d1*2)∪(d2*2)
-  @test d/2 == (d1/2)∪(d2/2)
-  @test 2\d == (2\d1)∪(2\d2)
+  @test d+1 == (d1+1) ∪ (d2+1)
+  @test d-1 == (d1-1) ∪ (d2-1)
+  @test 2d  == (2d1)  ∪ (2d2)
+  @test d*2 == (d1*2) ∪ (d2*2)
+  @test d/2 == (d1/2) ∪ (d2/2)
+  @test 2\d == (2\d1) ∪ (2\d2)
 
 
   println("- different types")
@@ -586,5 +590,5 @@ function test_set_operations()
   d1 = interval(0f0, 1f0)
   d2 = interval(2,3)
 
-  @test d1 ∪ d2 == d̃1 ∪ D2
+  @test d1 ∪ d2 == d̃1 ∪ d2
 end

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -89,6 +89,8 @@ function test_point()
     d2 = Point(1) ∪ Point(2) ∪ Point(3)
 
     @test d1 == d2
+
+    convert(Domain{Float64}, Point(1)) ≡ Point(1.0)
 end
 
 

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -426,7 +426,7 @@ function test_set_operations()
   d3 = rectangle(-.5,-.1,.5,.1)
 
   println("- union")
-  u1 =  d1+d2
+  u1 = d1+d2
   u2 = u1+d3
 
   u3 = d3|u1
@@ -438,6 +438,12 @@ function test_set_operations()
 
   @test y∉u3
   @test y∉u4
+
+  ũ1 = UnionDomain(d1,d2)
+  @test u1 == ũ1
+  ũ1 = UnionDomain((d1,d2))
+  @test u1 == ũ1
+  ũ1 = UnionDomain((d1,d2))
 
   show(io,u1)
   @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -7,6 +7,7 @@ function test_specific_domains()
     @testset "$(rpad("Specific domains",80))" begin
         test_emptyspace()
         test_fullspace()
+        test_point()
         test_interval()
         test_unitball()
         test_derived_unitball()
@@ -64,6 +65,22 @@ function test_fullspace()
     @test d2 == Domain(SVector{2,Float64})
     @test d2 == convert(Domain,SVector{2,Float64})
     @test d2 == convert(Domain{SVector{2,Float64}}, SVector{2,Float64})
+end
+
+function test_point()
+    d = Domain(1.0)
+    @test d isa Point
+    @test 1 ∈ d
+    @test 1.1 ∉ d
+
+    @test d+1 == Domain(2.0)
+    @test 1+d == Domain(2.0)
+    @test 1-d == Domain(0.0)
+    @test d-1 == Domain(0.0)
+    @test 2d  == Domain(2.0)
+    @test d*2 == Domain(2.0)
+    @test d/2 == Domain(0.5)
+    @test 2\d == Domain(0.5)
 end
 
 

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -319,6 +319,11 @@ function test_interval(T = Float64)
     @test d1 \ interval(-3one(T),zero(T)) == interval(zero(T),2one(T))
     @test d1 \ interval(-4one(T),-3one(T)) == d1
     @test d1 \ interval(-4one(T),4one(T)) == EmptySpace{T}()
+
+    d1 \ (-3one(T)) == d1
+    d1 \ (-2one(T)) == Interval{:open,:closed}(-2one(T),2one(T))
+    d1 \ (2one(T)) == Interval{:closed,:open}(-2one(T),2one(T))
+    d1 \ zero(T) == Interval{:closed,:open}(-2one(T),zero(T)) ∪ Interval{:open,:closed}(zero(T),2one(T))
 end
 
 function test_unitball()
@@ -544,11 +549,11 @@ function test_set_operations()
   d3 = rectangle(-.5,-.1,.5,.1)
 
   println("- union")
-  u1 = d1∪d2
-  u2 = u1∪d3
+  u1 = d1 ∪ d2
+  u2 = u1 ∪ d3
 
-  u3 = d3|u1
-  u4 = u1|u2
+  u3 = d3 ∪ u1
+  u4 = u1 ∪ u2
   x = SVector(0.,.15)
   y = SVector(1.1,.75)
   @test x∈u3
@@ -569,8 +574,7 @@ function test_set_operations()
   @test UnionDomain(d1,d2) == UnionDomain(d2,d1)
 
   show(io,u1)
-  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n\t2.\t: the 2-dimensional unit ball\n" ||
-        String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"
+  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"
 
   println("- intersection")
   d1 = disk()

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -30,6 +30,7 @@ function test_emptyspace()
     println("- an empty space")
     d1 = EmptySpace()
     show(io,d1)
+    @test isempty(d1)
     @test String(take!(io)) == "the empty space with eltype Float64"
     @test eltype(d1) == Float64
     @test 0.5 ∉ d1
@@ -42,6 +43,7 @@ function test_emptyspace()
     @test d2 \ d2 == d1
 
     d2 = EmptySpace(SVector{2,Float64})
+    @test isempty(d2)
     @test v[0.1,0.2] ∉ d2
 end
 
@@ -324,6 +326,16 @@ function test_interval(T = Float64)
     d1 \ (-2one(T)) == Interval{:open,:closed}(-2one(T),2one(T))
     d1 \ (2one(T)) == Interval{:closed,:open}(-2one(T),2one(T))
     d1 \ zero(T) == Interval{:closed,:open}(-2one(T),zero(T)) ∪ Interval{:open,:closed}(zero(T),2one(T))
+
+    # - empty interval
+    @test isempty(interval(one(T),zero(T)))
+    @test zero(T) ∉ interval(one(T),zero(T))
+    @test isempty(Interval{:open,:open}(zero(T),zero(T)))
+    @test zero(T) ∉ Interval{:open,:open}(zero(T),zero(T))
+    @test isempty(Interval{:open,:closed}(zero(T),zero(T)))
+    @test zero(T) ∉ Interval{:open,:closed}(zero(T),zero(T))
+    @test isempty(Interval{:closed,:open}(zero(T),zero(T)))
+    @test zero(T) ∉ Interval{:closed,:open}(zero(T),zero(T))
 end
 
 function test_unitball()

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -218,7 +218,7 @@ function test_interval(T = Float64)
     d2 = one(T) - d
     @test typeof(d2) <: AbstractInterval
     @test leftendpoint(d2) == zero(T)
-    @test rightendpoint(d2) == 2one(T)    
+    @test rightendpoint(d2) == 2one(T)
 
 
     # Scaling
@@ -501,7 +501,6 @@ end
 
 
 function test_set_operations()
-
   d1 = disk()
   d2 = interval(-.9,.9)^2
   d3 = rectangle(-.5,-.1,.5,.1)
@@ -568,4 +567,16 @@ function test_set_operations()
   y = SVector(0.,.25)
   @test x∈d
   @test x∈d
+
+  println("- arithmetic")
+  d1 = interval(0,1)
+  d2 = interval(2,3)
+  d = d1 ∪ d2
+
+  @test d+1 == (d1+1)∪(d2+1)
+  @test d-1 == (d1-1)∪(d2-1)
+  @test 2d == (2d1)∪(2d2)
+  @test d*2 == (d1*2)∪(d2*2)
+  @test d/2 == (d1/2)∪(d2/2)
+  @test 2\d == (2\d1)∪(2\d2)
 end

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -443,7 +443,10 @@ function test_set_operations()
   @test u1 == ũ1
   ũ1 = UnionDomain((d1,d2))
   @test u1 == ũ1
-  ũ1 = UnionDomain((d1,d2))
+  ũ2 = UnionDomain([d1,d2])
+  @test ũ2 == ũ2
+  @test u1 == ũ2
+
 
   show(io,u1)
   @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -37,6 +37,8 @@ function test_emptyspace()
     d2 = interval()
     @test d1 ∩ d2 == d1
     @test d1 ∪ d2 == d2
+    @test d2 \ d1 == d2
+    @test d2 \ d2 == d1
 
     d2 = EmptySpace(SVector{2,Float64})
     @test v[0.1,0.2] ∉ d2
@@ -285,6 +287,15 @@ function test_interval(T = Float64)
     # - intersection of non-overlapping intervals
     du6 = i1 ∩ i4
     @test typeof(du6) == EmptySpace{T}
+
+    # - setdiff of intervals
+    d1 = interval(-2one(T), 2one(T))
+    @test d1 \ interval(3one(T), 4one(T)) == d1
+    @test d1 \ interval(zero(T), one(T)) == interval(-2one(T),zero(T)) ∪ interval(one(T), 2one(T))
+    @test d1 \ interval(zero(T), 3one(T)) == interval(-2one(T),zero(T))
+    @test d1 \ interval(-3one(T),zero(T)) == interval(zero(T),2one(T))
+    @test d1 \ interval(-4one(T),-3one(T)) == d1
+    @test d1 \ interval(-4one(T),4one(T)) == EmptySpace{T}()
 end
 
 function test_unitball()

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -83,7 +83,10 @@ function test_point()
     @test d/2 == Domain(0.5)
     @test 2\d == Domain(0.5)
 
-    @test Domain(Set([1,2,3])) == Point(1) ∪ Point(2) ∪ Point(3)
+    d1 = Domain(Set([1,2,3]))
+    d2 = Point(1) ∪ Point(2) ∪ Point(3)
+
+    @test d1 == d2
 end
 
 
@@ -566,7 +569,8 @@ function test_set_operations()
   @test UnionDomain(d1,d2) == UnionDomain(d2,d1)
 
   show(io,u1)
-  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n\t2.\t: the 2-dimensional unit ball\n"
+  @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n\t2.\t: the 2-dimensional unit ball\n" ||
+        String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"
 
   println("- intersection")
   d1 = disk()

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -579,4 +579,12 @@ function test_set_operations()
   @test d*2 == (d1*2)∪(d2*2)
   @test d/2 == (d1/2)∪(d2/2)
   @test 2\d == (2\d1)∪(2\d2)
+
+
+  println("- different types")
+  d̃1 = interval(0,1)
+  d1 = interval(0f0, 1f0)
+  d2 = interval(2,3)
+
+  @test d1 ∪ d2 == d̃1 ∪ D2
 end

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -585,6 +585,8 @@ function test_set_operations()
   # ordering doesn't matter
   @test UnionDomain(d1,d2) == UnionDomain(d2,d1)
 
+  @test UnionDomain(UnionDomain(d1,d2),d3) == UnionDomain(d3,UnionDomain(d1,d2))
+
   show(io,u1)
   @test String(take!(io)) == "a union of 2 domains:\n\t1.\t: the 2-dimensional unit ball\n\t2.\t: the interval [-0.9, 0.9] x the interval [-0.9, 0.9]\n"
 


### PR DESCRIPTION
ApproxFun now passes all tests using Domains.jl, though there is still some work to be done.

This makes the following changes:

1. Support `convert(Domain{T}, d::Domain)` for each of the current domains. We use this to support `in` with different types.
2. Allow `UnionDomain(::AbstractVector)`. This may be removed if #9 goes ahead.
3. Support `==` and `hash` for `UnionDomain`, using a `Set` to resolve the issue of ordering
4. #7: Remove `+` and other synonyms for union
5. Support arithmetic for intervals and `UnionDomain`
6. Support, for example, `convert(Domain, Float64)`, which now returns a `FullSpace{Float64}()`
7. Implement `setdiff` for intervals and `UnionDomain`
8. #6: `Point` is now a domain
9. Properly support open and closed endpoints for intervals in `setdiff` and `union` (TODO: `intersect`)
10. Adds `minimum`, `maximum`, `supremum` and `infimum`. (TODO: `maximum(norm, ::Domain)` , etc., for higher dimensions.) for `UnionDomain` and intervals.